### PR TITLE
Remove AnsibleCU

### DIFF
--- a/config/meetups.yml
+++ b/config/meetups.yml
@@ -35,7 +35,6 @@ default:
     - Ansible-Copenhagen
     - Ansible-Cork-Ireland
     - Ansible-Crete
-    - AnsibleCU
     - Ansible-Dallas
     - Ansible-DC
     - Ansible-Delhi


### PR DESCRIPTION
As details for AnsibleCU meetups are not visible to non-members, and when they make changes it messes up the reports, let's remove the group from the track list