### PR TITLE
Update collections.yml CheckPoint collection metadata

### DIFF
--- a/config/collections.yml
+++ b/config/collections.yml
@@ -396,8 +396,8 @@ default:
     Repo: ansible.utils
     in_package: yes
   - Site: https://github.com
-    Org: ansible-collections
-    Repo: checkpoint
+    Org: CheckPointSW
+    Repo: CheckPointAnsibleMgmtCollection
     in_package: yes
   - Site: https://github.com
     Org: ansible-collections


### PR DESCRIPTION
According to https://github.com/ansible-collections/checkpoint README, the collection was moved to a third party repo